### PR TITLE
Workspace dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,6 +750,8 @@ version = "0.1.0"
 dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
+ "aws-smithy-types-convert",
+ "futures-util",
  "serde",
  "serde_dynamo",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,9 @@
 [workspace]
 members = ["dynamodb_utils", "s3_utils", "ssm_utils"]
 resolver = "2"
+
+[workspace.dependencies]
+aws-config = { version = "1.5.0", features = ["behavior-version-latest"] }
+thiserror = { version = "1" }
+serde = { version = "1" }
+serde_json = { version = "1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ version = "0.1.0"
 
 [workspace.dependencies]
 aws-config = { version = "1.5.0", features = ["behavior-version-latest"] }
+aws-smithy-types-convert = { version = "0.60.8", features = ["convert-streams"] }
+futures-util = "0.3.30"
 thiserror = { version = "1" }
 serde = { version = "1" }
 serde_json = { version = "1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 members = ["dynamodb_utils", "s3_utils", "ssm_utils"]
 resolver = "2"
 
+[workspace.package]
+version = "0.1.0"
+
 [workspace.dependencies]
 aws-config = { version = "1.5.0", features = ["behavior-version-latest"] }
 thiserror = { version = "1" }

--- a/dynamodb_utils/Cargo.toml
+++ b/dynamodb_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dynamodb_utils"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/dynamodb_utils/Cargo.toml
+++ b/dynamodb_utils/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 aws-config.workspace = true
+aws-smithy-types-convert.workspace = true
+futures-util.workspace = true
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/dynamodb_utils/Cargo.toml
+++ b/dynamodb_utils/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
+aws-config.workspace = true
+thiserror.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 aws-sdk-dynamodb = {version = "1.32.0"}
-thiserror = { version = "1" }
-serde = { version = "1" }
-serde_json = { version = "1" }
 serde_dynamo = { version = "4.2.14", features = ["aws-sdk-dynamodb+1"] }

--- a/dynamodb_utils/src/lib.rs
+++ b/dynamodb_utils/src/lib.rs
@@ -6,8 +6,13 @@ mod into_values;
 
 pub mod sdk {
     pub use aws_sdk_dynamodb::*;
+    pub use aws_smithy_types_convert::stream::*;
 }
 
 pub mod sdk_config {
     pub use aws_config::*;
+}
+
+pub mod serde_dynamo {
+    pub use serde_dynamo::*;
 }

--- a/s3_utils/Cargo.toml
+++ b/s3_utils/Cargo.toml
@@ -10,9 +10,9 @@ rust-version = "1.75.0"
 [dependencies]
 aws-config.workspace = true
 thiserror.workspace = true
+aws-smithy-types-convert.workspace = true
+futures-util.workspace = true
 aws-sdk-s3 = { version = "1.31.0" }
-aws-smithy-types-convert = { version = "0.60.8", features = ["convert-streams"] }
-futures-util = "0.3.30"
 tokio = { version = "1", default-features = false, features = ["io-util"] }
 base64 = { version = "0.21" }
 serde.workspace = true

--- a/s3_utils/Cargo.toml
+++ b/s3_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3_utils"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 publish = false
 rust-version = "1.75.0"

--- a/s3_utils/Cargo.toml
+++ b/s3_utils/Cargo.toml
@@ -8,15 +8,15 @@ rust-version = "1.75.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { version = "1.5.0", features = ["behavior-version-latest"] }
+aws-config.workspace = true
+thiserror.workspace = true
 aws-sdk-s3 = { version = "1.31.0" }
 aws-smithy-types-convert = { version = "0.60.8", features = ["convert-streams"] }
 futures-util = "0.3.30"
 tokio = { version = "1", default-features = false, features = ["io-util"] }
-thiserror = { version = "1" }
 base64 = { version = "0.21" }
-serde = { version = "1" }
-serde_json = { version = "1" }
+serde.workspace = true
+serde_json.workspace = true
 chrono = { version = "0.4.38", default-features = false, optional = true }
 
 [features]

--- a/ssm_utils/Cargo.toml
+++ b/ssm_utils/Cargo.toml
@@ -8,10 +8,10 @@ rust-version = "1.76.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-aws-config = { version = "1.5.0", features = ["behavior-version-latest"] }
+aws-config.workspace = true
+thiserror.workspace = true
 aws-sdk-ssm = { version = "1.30.0" }
 mini-moka = { version = "0.10.3", optional = true }
-thiserror = { version = "1" }
 
 [features]
 default = ["expire"]

--- a/ssm_utils/Cargo.toml
+++ b/ssm_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssm_utils"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 publish = false
 rust-version = "1.76.0"


### PR DESCRIPTION
workspaceのdependencyを使う

更にreexportを増やして、依存先がcrateのimportをしなくていいようにします。